### PR TITLE
[keycloak] major stuff happened here

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,3 +1,3 @@
 Thanks for wanting to contribute.
 
-Manual updates to the chart version are not needed any more. The version bumps are now based on commit messages. If you want to bump the major version include `major` in the commit message. For a feature release, include `feature` or `feat`. If you dont want to create a new release at all include `chore` in your commit message. The default is a new patch release. For the specific keywords have a look at `scripts/bump-version.py`.
+Manual updates to the chart version are not needed any more. The version bumps are now based on commit messages. If you want to bump the major version include `major` in the commit message. For a feature release, include `feature` or `feat`. If you don't want to create a new release at all include `chore` in your commit message. The default is a new patch release. For the specific keywords have a look at [the script](scripts/bump-version.py).

--- a/charts/keycloak/README.md
+++ b/charts/keycloak/README.md
@@ -2,6 +2,7 @@
 
 [Keycloak](http://www.keycloak.org/) is an open source identity and access management for modern applications and services.
 
+
 ## TL;DR;
 
 ```console


### PR DESCRIPTION
Signed-off-by: Mirco Hacker <mirco.hacker@codecentric.de>

Thanks for wanting to contribute.

Manual updates to the chart version are not needed any more. The version bumps are now based on commit messages. If you want to bump the major version include `major` in the commit message. For a feature release, include `feature` or `feat`. If you dont want to create a new release at all include `chore` in your commit message. The default is a new patch release. For the specific keywords have a look at `scripts/bump-version.py`.
