### PR TITLE
chore: all the labels

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,4 @@ venv
 charts/**/charts
 .cr-*
 /ct_*
+

--- a/charts/keycloak/ci/h2-values.yaml
+++ b/charts/keycloak/ci/h2-values.yaml
@@ -13,6 +13,7 @@ extraEnv: |
       -Djboss.modules.system.pkgs=$JBOSS_MODULES_SYSTEM_PKGS
       -Djava.awt.headless=true
 
+
 secrets:
   admin-creds:
     annotations:

--- a/charts/mailhog/templates/_helpers.tpl
+++ b/charts/mailhog/templates/_helpers.tpl
@@ -6,6 +6,7 @@ Expand the name of the chart.
 {{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" -}}
 {{- end -}}
 
+
 {{/*
 Create a default fully qualified app name.
 We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).

--- a/ct.yaml
+++ b/ct.yaml
@@ -5,3 +5,4 @@ chart-dirs:
 chart-repos:
   - bitnami=https://charts.bitnami.com/bitnami
 check-version-increment: false
+


### PR DESCRIPTION
Signed-off-by: Mirco Hacker <mirco.hacker@codecentric.de>

<!---
Thanks for wanting to contribute.

Manual updates to the chart version are not needed any more. The version bumps are now based on commit messages. If you want to bump the major version include `major` in the commit message. For a feature release, include `feature` or `feat`. If you don't want to create a new release at all, include `chore` in all your commit messages. The default is a new patch release. For the specific keywords have a look at [the script](scripts/bump-version.py).
--->
